### PR TITLE
(feat) support tmux users

### DIFF
--- a/plugin/zoom.vim
+++ b/plugin/zoom.vim
@@ -6,5 +6,9 @@ let g:loaded_zoom = 1
 nnoremap <silent> <Plug>(zoom-toggle) :call zoom#toggle()<CR>
 
 if !hasmapto('<Plug>(zoom-toggle)')
-  nmap <C-W>m <Plug>(zoom-toggle)
+  if $TMUX == ''
+    nmap <C-W>m <Plug>(zoom-toggle)
+  else
+    nmap <C-W>z <Plug>(zoom-toggle)
+  endif
 endif


### PR DESCRIPTION
Changes:
    - plugin/zoom.vim:8    Adds conditional to test for tmux

Adds
   - Control+W Z to zoom when tmux is detected else defaults to Control+W M to zoom